### PR TITLE
Fix error when downloading large file

### DIFF
--- a/obex.c
+++ b/obex.c
@@ -88,7 +88,7 @@ static void obex_event (obex_t *hdl, obex_object_t *obj, int mode,
     if (event == OBEX_EV_PROGRESS) {
         hd.bq4 = 0;
         size = 4;
-        rc = OBEX_ObjectAddHeader(hdl, obj, OBEX_HDR_CONNECTION, hd, size, OBEX_FL_FIT_ONE_PACKET);
+        rc = OBEX_ObjectAddHeader(hdl, obj, OBEX_HDR_CONNECTION, hd, size, 0);
         if (rc < 0) {
             printf("oah fail %d\n", rc);
         }

--- a/smartpen.c
+++ b/smartpen.c
@@ -71,7 +71,7 @@ static void obex_event (obex_t *hdl, obex_object_t *obj, int mode,
 		hd.bq4 = state->connid;
 		size = 4;
 		rc = OBEX_ObjectAddHeader(hdl, obj, OBEX_HDR_CONNECTION,
-					  hd, size, OBEX_FL_FIT_ONE_PACKET);
+					  hd, size, 0);
 		if (rc < 0) {
 			printf("oah fail %d\n", rc);
 		}


### PR DESCRIPTION
The Livescribe SmartPen firmware (at least v1.5) requires a Connection header after every Continue response (which contradicts the Obex spec). We convince openobex to send the header by calling OBEX_ObjectAddHeader in the event callback.

The problem is that openobex keeps counting request bytes, and when you set OBEX_FL_FIT_ONE_PACKET it will return error once all your Connection headers reach the 1kB MTU. The solution is to turn off that flag.

Example of getting error when the pen has a lot of data (in my case, PaperReplay is 1GB):

```
>>> import pysmartpen
>>> s = pysmartpen.Smartpen()
>>> s.connect(vendor=0x1cfb, product=0x1010)
>>> s.get_paperreplay('paperreplay')
oah fail -1
oah fail -1
FAIL 53 3
python: smartpen.c:83: obex_event: Assertion `0' failed.
Aborted (core dumped)
```
